### PR TITLE
Updates User-Agent header in requestWithBoundary

### DIFF
--- a/Vendor/BIT/CrashReports/BITCrashManager.m
+++ b/Vendor/BIT/CrashReports/BITCrashManager.m
@@ -1600,7 +1600,7 @@ __attribute__((noreturn)) static void uncaught_cxx_exception_handler(const BITCr
                                                               parameters:nil];
   
   [request setCachePolicy: NSURLRequestReloadIgnoringLocalCacheData];
-  [request setValue:@"HockeySDK/iOS" forHTTPHeaderField:@"User-Agent"];
+  [request setValue:@"BugSplat-iOS" forHTTPHeaderField:@"User-Agent"];
   [request setValue:@"gzip" forHTTPHeaderField:@"Accept-Encoding"];
   
   NSString *contentType = [NSString stringWithFormat:@"multipart/form-data; boundary=%@", boundary];


### PR DESCRIPTION
Both the HockeyApp SDK for macOS and iOS use HockeyApp/iOS as the value of the User-Agent header. This change sets a custom User-Agent and allows BugSplat to determine which crashes are from the iOS SDK.

Fixes #1